### PR TITLE
alter the variable as refresh token name and declaration

### DIFF
--- a/context/jwt.go
+++ b/context/jwt.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const RefreshToken = "refresh-token"
+const refreshTokenName = "refresh-token"
 
 type JWTConfig struct {
 	SigningKey       []byte
@@ -55,7 +55,7 @@ func (j *JWT) SetRefreshTokenWithClaims(claims jwt.Claims) (string, error) {
 	}
 
 	ck := new(http.Cookie)
-	ck.Name = RefreshToken
+	ck.Name = refreshTokenName
 	ck.Domain = j.domain
 	ck.Path = j.path
 	ck.HttpOnly = true
@@ -91,7 +91,7 @@ func (j *JWT) MakeRefreshToken(claims jwt.Claims) (string, error) {
 var errInvalidToken = errors.New("invalid token error")
 
 func (j *JWT) GetRefreshTokenFromCookie() (jwt.Claims, error) {
-	ck, err := j.request.Cookie(RefreshToken)
+	ck, err := j.request.Cookie(refreshTokenName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It is a tweak to alter refresh token variable in jwt.go

1. access modifier (public to private)
2. variable name